### PR TITLE
fix badge index export

### DIFF
--- a/src/badge/index.ts
+++ b/src/badge/index.ts
@@ -1,0 +1,1 @@
+export * from "./Badge";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
-import * as colors from './foundation/colors';
+import * as colors from "./foundation/colors";
 
 export { colors };
 
-export * from './button';
+export * from "./button";
+export * from "./badge";


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.1.4-canary.5.2dae514a070a8ee7d964b6b9b5afc2d65bf4c4f6.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install another-gs-ds-component-library@0.1.4-canary.5.2dae514a070a8ee7d964b6b9b5afc2d65bf4c4f6.0
  # or 
  yarn add another-gs-ds-component-library@0.1.4-canary.5.2dae514a070a8ee7d964b6b9b5afc2d65bf4c4f6.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
