### PR TITLE
Add optional git ref to canary build

### DIFF
--- a/.github/workflows/push_canary.yml
+++ b/.github/workflows/push_canary.yml
@@ -1,25 +1,39 @@
 # .github/workflows/push.yml
 
 name: Release Canary
-on: [workflow_dispatch]
+on:
+  workflow_dispatch:
+    inputs:
+      git-ref:
+        description: Git Ref (Optional)
+        required: false
 
 jobs:
   canary_release:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Repo
-        uses: actions/checkout@master
+      - name: Clone Repository (Latest)
+        uses: actions/checkout@v2
+        if: github.event.inputs.git-ref == ''
         with:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
 
+      - name: Clone Repository (Custom Ref)
+        uses: actions/checkout@v2
+        if: github.event.inputs.git-ref != ''
+        with:
+          ref: ${{ github.event.inputs.git-ref }}
+          # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
+          fetch-depth: 0
+
       - name: Setup Node.js 12.x
-        uses: actions/setup-node@master
+        uses: actions/setup-node@v2
         with:
           node-version: 12.x
 
       - name: Cache node modules
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: node_modules
           key: yarn-deps-${{ hashFiles('yarn.lock') }}


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.1.4-canary.7.7fb5d64.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install another-gs-ds-component-library@0.1.4-canary.7.7fb5d64.0
  # or 
  yarn add another-gs-ds-component-library@0.1.4-canary.7.7fb5d64.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
